### PR TITLE
Various enhancements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,13 +17,15 @@
   "dependencies": {
     "angular": "^1.3.0",
     "angular-sanitize": "~1.3.15",
-    "angular-animate": "~1.3.15"
+    "angular-animate": "~1.3.15",
+    "angular-mocks": "~1.3.15"
   },
   "devDependencies": {
     "angular-mocks": "1.3.0",
     "angular-scenario": "1.3.0"
   },
   "resolutions": {
-    "angular": "^1.3.0"
+    "angular": "^1.3.0",
+    "angular-mocks": "~1.3.15"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,24 +1,29 @@
 {
-	"name": "nHttpInceptor",
-	"version": "1.0.0",
-	"description": "",
-	"homepage": "",
-	"author": "Tommy Jepsen",
-	"repository": {
-		"type": "git",
-		"url": ""
-	},
-	"main": [
-		""
-	],
-	"ignore": [
-		"demo"
-	],
-	"dependencies": {
-		"angular": "^1.3.0"
-	},
-	"devDependencies": {
-		"angular-mocks": "1.3.0",
-		"angular-scenario": "1.3.0"
-	}
+  "name": "nHttpInceptor",
+  "version": "1.0.0",
+  "description": "",
+  "homepage": "",
+  "author": "Tommy Jepsen",
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
+  "main": [
+    ""
+  ],
+  "ignore": [
+    "demo"
+  ],
+  "dependencies": {
+    "angular": "^1.3.0",
+    "angular-sanitize": "~1.3.15",
+    "angular-animate": "~1.3.15"
+  },
+  "devDependencies": {
+    "angular-mocks": "1.3.0",
+    "angular-scenario": "1.3.0"
+  },
+  "resolutions": {
+    "angular": "^1.3.0"
+  }
 }

--- a/index.html
+++ b/index.html
@@ -37,12 +37,18 @@
 		<script src="bower_components/angular/angular.js"></script>
 		<!-- endbower -->
 
-		<script src="src/nhttpinceptor.module.js"></script>
-		<script src="src/nhttpinceptor.provider.js"></script>
-		<script src="src/nhttpinceptor.factory.js"></script>
+		<script src="src/nhttpinterceptor.module.js"></script>
+		<script src="src/nhttpinterceptor.provider.js"></script>
+		<script src="src/nhttpinterceptor.factory.js"></script>
 
 		<script>
-			angular.module('demoApp', ['nhttpinceptor']);
+			angular.module('demoApp', ['nHttpInterceptor']);
+
+			angular.module('demoApp')
+					.config(configure);
+			function configure($httpProvider, nHttpInterceptorProvider) {
+				console.log('greetings from config', nHttpInterceptorProvider);
+			}
 		</script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,34 +9,18 @@
 	</head>
 	<body ng-app="demoApp">
 
-		<h1>Nodes Module Starter Kit bids you welcome!</h1>
-		<hr/>
-		<p>Before you get started writing your next Angular Module, you need to set up a few things:</p>
-		<ol>
-			<li>Come up with an awesome name for your module</li>
-			<li>Rename the files in the <pre>src/</pre> folder to your awesome name</li>
-			<li>Fill out the information in <pre>package.json</pre> and <pre>bower.json</pre> (name, description, etc.)</li>
-			<li>Correct the references in index.html to the styles and scripts</li>
-			<li>Create a repository for your module on Github</li>
-		</ol>
-		<hr/>
-		<p>When you are ready to release your package to the world, run <pre>grunt build</pre> - this will copy the scss files,
-		and concatinate the javascript files.</p>
-		<p>A more comprehensive guide for submitting your package to Bower is in the works.</p>
-		<hr/>
-		<p>We also recommend doing your fellow developers a few favors:</p>
-		<ul>
-			<li>Write a guide on how to use your module in the readme.md file</li>
-			<li>Write a few demo examples so people can see the intended use</li>
-			<li>If you want to go all the way, make a Github Pages branch, this will give your module a little home on the web where you can host your demos</li>
-		</ul>
-
-		<module-name></module-name>
+		<h1>nHttpInterceptor Module</h1>
+		<p>Test it:</p>
+		<div ng-controller="demoCtrl as demo">
+			<button ng-click="demo.causeError()">Lav en fejl!</button>
+		</div>
+		<nodes-messages-wrapper></nodes-messages-wrapper>
 
 		<!-- bower:js -->
 		<script src="bower_components/angular/angular.js"></script>
 		<script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
 		<script src="bower_components/angular-animate/angular-animate.js"></script>
+		<script src="bower_components/angular-mocks/angular-mocks.js"></script>
 		<!-- endbower -->
 
 		<script src="src/nhttpinterceptor.module.js"></script>
@@ -45,18 +29,68 @@
 
 		<script src="nMessages.js"></script>
 
+		<!-- Create a fake backend -->
 		<script>
-			angular.module('demoApp', ['nHttpInterceptor', 'messages']);
+			angular.module('fakeBackend', ['ngMockE2E'])
+					.run(function($httpBackend) {
+						// Some possible errors
+						var defaultErrors = {
+							304: '304',
+							401: '401',
+							403: '403',
+							404: '404',
+							412: '412',
+							440: '440',
+							441: '441',
+							442: '442',
+							443: '443',
+							445: '445',
+							500: '500'
+						};
+						// Pick a random error
+						function pickRandomError() {
+							var result;
+							var count = 0;
+							for (var prop in defaultErrors) {
+								if(Math.random() < 1 / ++count) {
+									result = prop;
+								}
+							}
+							return result;
+						}
 
+						$httpBackend.whenGET('/create-error').respond(function(url) {
+							var errorCode = pickRandomError();
+							var errorMsg = defaultErrors[errorCode];
+							return [errorCode, errorMsg, {}];
+						});
+
+					});
+		</script>
+
+		<script>
+			angular.module('demoApp', ['nHttpInterceptor', 'messages', 'fakeBackend']);
+
+			// Make sure the translate object is available on the $rootScope
+			// Fill out one key, to show that translate keys will always supercede any defaults
+			angular.module('demoApp')
+					.run(function($rootScope) {
+						$rootScope.translate = {
+							error304: 'I came from the translate object!'
+						};
+					});
+
+			// Setup nHttpInterceptor
 			angular.module('demoApp')
 					.config(configure);
 			function configure($httpProvider, nHttpInterceptorProvider) {
-				// Set up the error messages custom
-				// You can set error401 to a translate key, fx "errorRandomMsg". It will then output the translate key,
-				// and if it does not exist, then it will output "errorRandomMsg"
+
+				// Example: override default message
 				nHttpInterceptorProvider.configure({
-					error401: "Du har ikke adgang til dette."
+					error440: 'Intet accepterings hovede.'
 				});
+
+				// Setup interceptors
 				$httpProvider.interceptors.push(function($q, nHttpInterceptorFactory) {
 					return {
 						responseError: function(res) {
@@ -68,6 +102,16 @@
 					};
 				});
 
+			}
+
+			// Create a demo controller for testing purposes
+			angular.module('demoApp')
+					.controller('demoCtrl', demoCtrl);
+			function demoCtrl($http) {
+				var vm = this;
+				vm.causeError = function() {
+					$http.get('/create-error');
+				}
 			}
 		</script>
 	</body>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,23 @@
 			angular.module('demoApp')
 					.config(configure);
 			function configure($httpProvider, nHttpInterceptorProvider) {
-				console.log('greetings from config', nHttpInterceptorProvider);
+				// Set up the error messages custom
+				// You can set error401 to a translate key, fx "errorRandomMsg". It will then output the translate key,
+				// and if it does not exist, then it will output "errorRandomMsg"
+				nHttpInterceptorProvider.configure({
+					error401: "Du har ikke adgang til dette."
+				});
+				$httpProvider.interceptors.push(function($q, nHttpInterceptorFactory) {
+					return {
+						responseError: function(res) {
+
+							nHttpInterceptorFactory.errorHandle(res.status);
+
+							return $q.reject(res);
+						}
+					};
+				});
+
 			}
 		</script>
 	</body>

--- a/index.html
+++ b/index.html
@@ -35,14 +35,18 @@
 
 		<!-- bower:js -->
 		<script src="bower_components/angular/angular.js"></script>
+		<script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
+		<script src="bower_components/angular-animate/angular-animate.js"></script>
 		<!-- endbower -->
 
 		<script src="src/nhttpinterceptor.module.js"></script>
 		<script src="src/nhttpinterceptor.provider.js"></script>
 		<script src="src/nhttpinterceptor.factory.js"></script>
 
+		<script src="nMessages.js"></script>
+
 		<script>
-			angular.module('demoApp', ['nHttpInterceptor']);
+			angular.module('demoApp', ['nHttpInterceptor', 'messages']);
 
 			angular.module('demoApp')
 					.config(configure);

--- a/nMessages.js
+++ b/nMessages.js
@@ -18,7 +18,7 @@
 		var directive = {
 			restrict: 'EA',
 			transclude: true,
-			templateUrl: 'src/messages.message.template.html',
+			templateUrl: 'messages.message.template.html',
 			scope: {
 				message: '=nodesMessagesMessage'
 			},
@@ -30,13 +30,13 @@
 		function link(scope, element) {
 			if (scope.message.dismissOnTimeout) {
 				$timeout(function () {
-					nodesMessages.dismiss(scope.message.id);
+					messages.dismiss(scope.message.id);
 				}, scope.message.timeout);
 			}
 
 			if (scope.message.dismissOnClick) {
 				element.bind('click', function () {
-					nodesMessages.dismiss(scope.message.id);
+					messages.dismiss(scope.message.id);
 					scope.$apply();
 				});
 			}
@@ -44,12 +44,12 @@
 
 		function controller($scope, nodesMessages) {
 			$scope.dismiss = function () {
-				nodesMessages.dismiss($scope.message.id);
+				messages.dismiss($scope.message.id);
 			};
 		}
 
 	}
-	message.$inject = ["nodesMessages", "$timeout"];
+	message.$inject = ["messages", "$timeout"];
 
 })();
 
@@ -106,7 +106,6 @@
 			this.dismissOnClick = defaults.dismissOnClick;
 
 			angular.extend(this, msg);
-			console.log(this)
 
 		}
 
@@ -179,7 +178,7 @@
 			restrict: 'EA',
 			replace: true,
 			compile: compile,
-			templateUrl: 'src/messages.wrapper.template.html'
+			templateUrl: 'messages.wrapper.template.html'
 		};
 		return directive;
 
@@ -187,15 +186,15 @@
 
 			return function(scope) {
 				// pænere end ..Pos!
-				scope.hPos = nodesMessages.settings.horizontalPosition;
-				scope.vPos = nodesMessages.settings.verticalPosition;
+				scope.hPos = messages.settings.horizontalPosition;
+				scope.vPos = messages.settings.verticalPosition;
 
-				scope.messages = nodesMessages.messages;
+				scope.messages = messages.messages;
 			};
 		}
 
 	}
-	wrapper.$inject = ["nodesMessages"];
+	wrapper.$inject = ["messages"];
 
 })();
 

--- a/nMessages.js
+++ b/nMessages.js
@@ -1,0 +1,225 @@
+/**
+ *
+ * @version v1.0.0 - 2015-04-01
+ * @link
+	* @author
+ * @license MIT License, http://www.opensource.org/licenses/MIT
+ */
+(function () {
+	'use strict';
+
+	angular
+		.module('messages.message', ['messages.provider'])
+		.directive('nodesMessagesMessage', message);
+
+	/* @ngInject */
+	function message(messages, $timeout) {
+
+		var directive = {
+			restrict: 'EA',
+			transclude: true,
+			templateUrl: 'src/messages.message.template.html',
+			scope: {
+				message: '=nodesMessagesMessage'
+			},
+			link: link,
+			controller: controller
+		};
+		return directive;
+
+		function link(scope, element) {
+			if (scope.message.dismissOnTimeout) {
+				$timeout(function () {
+					nodesMessages.dismiss(scope.message.id);
+				}, scope.message.timeout);
+			}
+
+			if (scope.message.dismissOnClick) {
+				element.bind('click', function () {
+					nodesMessages.dismiss(scope.message.id);
+					scope.$apply();
+				});
+			}
+		}
+
+		function controller($scope, nodesMessages) {
+			$scope.dismiss = function () {
+				nodesMessages.dismiss($scope.message.id);
+			};
+		}
+
+	}
+	message.$inject = ["nodesMessages", "$timeout"];
+
+})();
+
+(function () {
+	'use strict';
+
+	angular.module('messages', [
+		'ngSanitize',
+		'ngAnimate',
+		'messages.provider',
+		'messages.wrapper',
+		'messages.message'
+	]);
+
+})();
+
+(function () {
+	'use strict';
+
+	angular
+		.module('messages.provider', [])
+		.provider('messages', messagesProvider);
+
+	function messagesProvider() {
+		var messages = [],
+			messageStack = [];
+
+		var defaults = {
+			type: 'success',
+			dismissOnTimeout: true,
+			timeout: 4000,
+			dismissButton: false,
+			dismissButtonHtml: '&times;',
+			dismissOnClick: true,
+			horizontalPosition: 'center',
+			verticalPosition: 'top',
+			maxNumber: 0
+		};
+
+		function Message(msg) {
+
+			var id = Math.floor(Math.random()*1000);
+
+			while (messages.indexOf(id) > -1) {
+				id = Math.floor(Math.random()*1000);
+			}
+
+			this.id = id;
+			this.type = defaults.type;
+			this.dismissOnTimeout = defaults.dismissOnTimeout;
+			this.timeout = defaults.timeout;
+			this.dismissButton = defaults.dismissButton;
+			this.dismissButtonHtml = defaults.dismissButtonHtml;
+			this.dismissOnClick = defaults.dismissOnClick;
+
+			angular.extend(this, msg);
+			console.log(this)
+
+		}
+
+		this.configure = function(config) {
+			angular.extend(defaults, config);
+		};
+
+		this.$get = [function() {
+			return {
+				settings: defaults,
+				messages: messages,
+				dismiss: function(id) {
+					if (id) {
+
+						for (var i = messages.length - 1; i >= 0; i--) {
+							if (messages[i].id === id) {
+								messages.splice(i, 1);
+								messageStack.splice(messageStack.indexOf(id), 1);
+								return;
+							}
+						}
+
+					} else {
+
+						while(messages.length > 0) {
+							messages.pop();
+						}
+
+						messageStack = [];
+					}
+				},
+				create: function(msg) {
+
+					if (defaults.maxNumber > 0 &&
+						messageStack.length >= defaults.maxNumber) {
+						this.dismiss(messageStack[0]);
+					}
+
+					msg = (typeof msg === 'string') ? {content: msg} : msg;
+
+					var newMsg = new Message(msg);
+
+					if(defaults.verticalPosition === 'bottom') {
+						messages.unshift(newMsg);
+					} else {
+						messages.push(newMsg);
+					}
+
+					messageStack.push(newMsg.id);
+
+					return newMsg.id;
+				}
+			};
+		}];
+	}
+
+})();
+
+(function () {
+	'use strict';
+
+	angular
+		.module('messages.wrapper', ['messages.provider'])
+		.directive('nodesMessagesWrapper', wrapper);
+
+	/* @ngInject */
+	function wrapper(messages) {
+
+		var directive = {
+			restrict: 'EA',
+			replace: true,
+			compile: compile,
+			templateUrl: 'src/messages.wrapper.template.html'
+		};
+		return directive;
+
+		function compile(tElem, tAttrs) {
+
+			return function(scope) {
+				// pænere end ..Pos!
+				scope.hPos = nodesMessages.settings.horizontalPosition;
+				scope.vPos = nodesMessages.settings.verticalPosition;
+
+				scope.messages = nodesMessages.messages;
+			};
+		}
+
+	}
+	wrapper.$inject = ["nodesMessages"];
+
+})();
+
+angular.module('messages').run(['$templateCache', function($templateCache) {
+	'use strict';
+
+	$templateCache.put('messages.message.template.html',
+		"<div class=\"messages__message {{message.type}}\">\n" +
+		"\n" +
+		"\t<a class=\"messages__close-button\" ng-if=\"message.dismissButton\" ng-bind-html=\"message.dismissButtonHtml\" ng-click=\"!message.dismissOnClick && dismis()\"></a>\n" +
+		"\n" +
+		"\t<span class=\"messages__content\" ng-transclude=\"\"></span>\n" +
+		"</div>"
+	);
+
+
+	$templateCache.put('messages.wrapper.template.html',
+		"<div class=\"messages messages--{{hPos}}-{{vPos}}\">\n" +
+		"\t<ul class=\"messages__list\">\n" +
+		"\t\t<li ng-repeat=\"message in messages track by $index\" messages-message=\"message\">\n" +
+		"\t\t\t<span ng-bind-html=\"message.content\"></span>\n" +
+		"\t\t</li>\n" +
+		"\t</ul>\n" +
+		"</div>"
+	);
+
+}]);

--- a/src/nhttpinceptor.module.js
+++ b/src/nhttpinceptor.module.js
@@ -1,5 +1,0 @@
-(function() {
-	'use strict';
-
-	angular.module('nHttpInceptor', ['nHttpInceptor.provider', 'nHttpInceptor.factory']);
-})();

--- a/src/nhttpinterceptor.factory.js
+++ b/src/nhttpinterceptor.factory.js
@@ -2,11 +2,11 @@
 	'use strict';
 
 	angular
-		.module('nHttpInceptor.factory', ['nHttpInceptor.provider'])
-		.factory('nHttpInceptor', nHttpInceptor);
+		.module('nHttpInterceptor.factory', ['nHttpInterceptor.provider'])
+		.factory('nHttpInterceptor', nHttpInterceptor);
 
 	/* @ngInject */
-	function nHttpInceptor(nhttpinceptor, $rootScope, messages) {
+	function nHttpInterceptor(nHttpInterceptor, $rootScope, messages) {
 
 		var service = {
 			errorHandle: errorHandle
@@ -20,15 +20,15 @@
 
 			/* Message it out */
 			/* If it exists in translate, then message it, or else message the string */
-			if($rootScope.translate[nhttpinceptor.errorMessages[getErrorMsg]]) {
+			if($rootScope.translate[nHttpInterceptor.errorMessages[getErrorMsg]]) {
 				messages.create({
 					type: 'alert',
-					content: $rootScope.translate[nhttpinceptor.errorMessages[getErrorMsg]]
+					content: $rootScope.translate[nHttpInterceptor.errorMessages[getErrorMsg]]
 				})
 			} else {
 				messages.create({
 					type: 'alert',
-					content: nhttpinceptor.errorMessages[getErrorMsg]
+					content: nHttpInterceptor.errorMessages[getErrorMsg]
 				})
 			}
 		}

--- a/src/nhttpinterceptor.factory.js
+++ b/src/nhttpinterceptor.factory.js
@@ -3,10 +3,10 @@
 
 	angular
 		.module('nHttpInterceptor.factory', ['nHttpInterceptor.provider'])
-		.factory('nHttpInterceptor', nHttpInterceptor);
+		.factory('nHttpInterceptorFactory', interceptorFactory);
 
 	/* @ngInject */
-	function nHttpInterceptor(nHttpInterceptor, $rootScope, messages) {
+	function interceptorFactory(nHttpInterceptor, $rootScope, messages) {
 
 		var service = {
 			errorHandle: errorHandle
@@ -16,7 +16,7 @@
 
 		function errorHandle(statuscode) {
 			/* Convert it so match the object with keys and errormessages in */
-			var getErrorMsg = "error" + statuscode;
+			var getErrorMsg = 'error' + statuscode;
 
 			/* Message it out */
 			/* If it exists in translate, then message it, or else message the string */
@@ -24,14 +24,14 @@
 				messages.create({
 					type: 'alert',
 					content: $rootScope.translate[nHttpInterceptor.errorMessages[getErrorMsg]]
-				})
+				});
 			} else {
 				messages.create({
 					type: 'alert',
 					content: nHttpInterceptor.errorMessages[getErrorMsg]
-				})
+				});
 			}
 		}
-	};
+	}
 
 })();

--- a/src/nhttpinterceptor.factory.js
+++ b/src/nhttpinterceptor.factory.js
@@ -20,10 +20,10 @@
 
 			/* Message it out */
 			/* If it exists in translate, then message it, or else message the string */
-			if($rootScope.translate[nHttpInterceptor.errorMessages[getErrorMsg]]) {
+			if($rootScope.translate[getErrorMsg]) {
 				messages.create({
 					type: 'alert',
-					content: $rootScope.translate[nHttpInterceptor.errorMessages[getErrorMsg]]
+					content: $rootScope.translate[getErrorMsg]
 				});
 			} else {
 				messages.create({

--- a/src/nhttpinterceptor.module.js
+++ b/src/nhttpinterceptor.module.js
@@ -1,5 +1,5 @@
 (function() {
 	'use strict';
 
-	angular.module('nHttpInterceptor', ['nHttpInterceptor.provider', 'nHttpInterceptor.factory']);
+	angular.module('nHttpInterceptor', ['nHttpInterceptor.provider', 'nHttpInterceptor.factory', 'messages']);
 })();

--- a/src/nhttpinterceptor.module.js
+++ b/src/nhttpinterceptor.module.js
@@ -1,0 +1,5 @@
+(function() {
+	'use strict';
+
+	angular.module('nHttpInterceptor', ['nHttpInterceptor.provider', 'nHttpInterceptor.factory']);
+})();

--- a/src/nhttpinterceptor.provider.js
+++ b/src/nhttpinterceptor.provider.js
@@ -2,11 +2,11 @@
 	'use strict';
 
 	angular
-		.module('nHttpInceptor.provider', [])
-		.provider('nhttpinceptor', nhttpinceptor);
+		.module('nHttpInterceptor.provider', [])
+		.provider('nHttpInterceptor', interceptor);
 
 	/* @ngInject */
-	function nhttpinceptor() {
+	function interceptor() {
 
 		/* Defaults messages on error */
 		var defaults = {

--- a/src/nhttpinterceptor.provider.js
+++ b/src/nhttpinterceptor.provider.js
@@ -3,10 +3,10 @@
 
 	angular
 		.module('nHttpInterceptor.provider', [])
-		.provider('nHttpInterceptor', interceptor);
+		.provider('nHttpInterceptor', interceptorProvider);
 
 	/* @ngInject */
-	function interceptor() {
+	function interceptorProvider() {
 		/*jshint validthis: true */
 
 		/* Defaults messages on error */
@@ -33,6 +33,6 @@
 				errorMessages: defaults
 			};
 		}];
-	};
+	}
 
 })();

--- a/src/nhttpinterceptor.provider.js
+++ b/src/nhttpinterceptor.provider.js
@@ -7,6 +7,7 @@
 
 	/* @ngInject */
 	function interceptor() {
+		/*jshint validthis: true */
 
 		/* Defaults messages on error */
 		var defaults = {


### PR DESCRIPTION
This pull request contains:
- Code cleanup:
  Making sure the code validates to the jshint definitions used in Nodes (double quotation marks instead of single, missing semi-colons, missing jshint options to validate providers)
- Fix $rootScope.translate lookups
  Was looking for values in the object instead of keys.
- Rename files (and modules, read further down):
  The name Inceptor is unclear compared to what this module does (it intercepts).
- Rename modules:
  -- provider is now nHttpInterceptor
  -- factory is now nHttpInterceptorFactory
  -- module functions are now camelCased. Naming follows Angular best-practices for factories:
  
  > "Best Practice: name the factory functions as <serviceId>Factory (e.g., apiTokenFactory). While this naming convention is not required, it helps when navigating the codebase or looking at stack traces in the debugger."
  > [link](https://docs.angularjs.org/guide/providers)
- Adds a "custom" version of the WIP nMessages (and its dependencies) module so that the standalone demo does not fail.
  (This needs to be fixed in a future update to nHttpInterceptor)
- Adds a translate object to the $rootScope so that the standalone demo does not fail.
- Add a demo to index.html including a mockE2E server to respond to http requests (and throw random errors yarr)
- Remove "default" copy from index.html
